### PR TITLE
Update pytype dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,5 @@ from setuptools import setup
 setup(
     name='pre_commit_dummy_package',
     version='0.0.0',
-    install_requires=['pytype==2019.05.31'],
+    install_requires=['pytype==2019.9.6'],
 )

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,5 @@ from setuptools import setup
 setup(
     name='pre_commit_dummy_package',
     version='0.0.0',
-    install_requires=['pytype==2019.9.6'],
+    install_requires=['pytype==2019.10.17'],
 )


### PR DESCRIPTION
Update to `pytype==2019.9.6` -- this should probably be accompanied by a tag `2019.9.6` when merged.